### PR TITLE
Updating deprecated octal notation.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ function mktmpdir(prefixSuffix, tmpdir, callback, onend) {
   tmpname.create(prefixSuffix, tmpdir, function(err, path, next) {
     if (err) return callback(err);
 
-    fs.mkdir(path, 0700, next);
+    fs.mkdir(path, 0o700, next);
   }, function(err, path) {
     if (err) return callback(err);
 


### PR DESCRIPTION
Omitting "o" when using an octal number has been deprecated for at least a couple years now.